### PR TITLE
#335 - Implement CardStamp positions

### DIFF
--- a/src/scss/components/card.scss
+++ b/src/scss/components/card.scss
@@ -67,8 +67,38 @@ $prefix-card-status : $prefix-card +'-status';
 				@extend .bg-#{$key};
 			}
 		}
-	}
 
+		&-position-top-start {
+			top: 0;
+			left: 0;
+
+			.#{$prefix-card}-stamp-icon {
+				transform: rotate(-10deg);
+				right: calc(var(--stamp-size) * 0.25);
+			}
+		}
+
+		&-position-bottom-start {
+			bottom: 0;
+			left: 0;
+			top: auto;
+
+			.#{$prefix-card}-stamp-icon {
+				top: calc(var(--stamp-size) * 0.25);
+				right: calc(var(--stamp-size) * 0.25);
+			}
+		}
+
+		&-position-bottom-end {
+			bottom: 0;
+			top: auto;
+
+			.#{$prefix-card}-stamp-icon {
+				transform: rotate(-10deg);
+				top: calc(var(--stamp-size) * 0.25);
+			}
+		}
+	}
 }
 
 // Card Status


### PR DESCRIPTION
@pournasserian tabler doesn't have classes for card-stamp positons, I wrote custom css for it

I don't know this is acceptable or not, but this was the only way that we could implement positions for CardStamp component.

one solution is to have a .scss file for missing classes of tabler (with tabler coding standards) and add classes like .card-stamp-top-start, .card-stamp-bottom-start, .card-stamp-bottom-end, etc.

even we can open PR for tabler repository and improve tabler with these fixes