### PR TITLE
Feat/docs style

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ Once installed, you can import the components and use them in your Svelte applic
 <Button>Hello uBeac</Button>
 ```
 
+## Styles
+
+uBeac components have default styles which is based on tabler. which you can use like this:
+
+```svelte
+<script>
+	import {Button} from '@ubeac/svelte'
+	import '@ubeac/svelte/styles/tabler.css'
+
+</script>
+
+<Button>Hello World!</Button>
+```
+
 ## Demo
 
 Check out the [documentation website](https://svelte.ubeac.io/) for live demos of each component and detailed usage instructions.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ubeac/svelte",
-	"version": "0.1.2",
+	"version": "0.1.3-next.0",
 	"description": "uBeac's Opinionated Svelte Component library",
 	"sideEffects": false,
 	"keywords": [


### PR DESCRIPTION
@pournasserian it is hard to import tabler's `.scss` files in other projects. because tabler has codes like this:
```scss
@import "~bootstrap/scss/root";
```

users should write this code in their project's `svelte.config.js`
```js
// in preprocessors section
sveltePreprocess({
    scss: {
        importer(url) {
            if (url[0] === '~') {
                url = path.resolve('node_modules', url.substr(1))
            }
	    return { file: url }
        },
    },
})
```

should I write about this? or is there any better solution? (maybe support importing of bootstrap's scss files. to extend bootstrap functionality and not tabler)

* Also @tabler/core is not in dependencies of this project.
